### PR TITLE
Update go get exmaple

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,7 +8,7 @@ Apex is a small tool for deploying and managing [AWS Lambda](https://aws.amazon.
 Download [binaries](https://github.com/apex/apex/releases) or:
 
 ```
-$ go get github.com/apex/apex/...
+$ go get github.com/apex/apex/cmd/apex
 ```
 
 ## Runtimes


### PR DESCRIPTION
Change go get example so apex gets automatically installed after downloading. Otherwise if getting `/apex/apex` manual build / installation is necessary.