### PR TITLE
Add name template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,6 @@ test:
 	@go test -cover ./...
 .PHONY: test
 
-cov:
-	@go test -covermode=count -coverprofile=cov.out ./$(PKG)
-	@go tool cover -html=cov.out
-	@rm cov.out
-.PHONY: cov
-
 build:
 	@gox -os="linux darwin windows" ./...
 .PHONY: build

--- a/Readme.md
+++ b/Readme.md
@@ -24,6 +24,7 @@ Currently supports:
 - Supports languages Lambda does not natively support via shim, such as Go
 - Binary install (useful for continuous deployment in CI etc)
 - Project level function and resource management
+- Configuration inheritance and overrides
 - Command-line function invocation with JSON streams
 - Transparently generates a zip for your deploy
 - Function rollback support
@@ -58,7 +59,7 @@ The project.json file defines project level configuration that applies to all fu
 }
 ```
 
-Each function uses a function.json configuration file to define function-specific properties such as the runtime, amount of memory allocated, and timeout. For example:
+Each function uses a function.json configuration file to define function-specific properties such as the runtime, amount of memory allocated, and timeout. This file is completely optional, as you can specify defaults in your project.json file. For example:
 
 ```json
 {
@@ -113,6 +114,8 @@ Or whitelist functions to deploy:
 ```
 $ apex deploy foo bar
 ```
+
+See the [Wiki](https://github.com/apex/apex/wiki) for more information.
 
 ## Credentials
 

--- a/cmd/apex/apex.go
+++ b/cmd/apex/apex.go
@@ -172,12 +172,12 @@ func invoke(project *project.Project, name []string, verbose, async bool) {
 		}
 
 		if err != nil {
-			log.Fatalf("error: %s", err)
+			log.Fatalf("error parsing response: %s", err)
 		}
 
 		reply, logs, err := fn.Invoke(v.Event, v.Context, kind)
 		if err != nil {
-			log.Fatalf("error: %s", err)
+			log.Fatalf("error response: %s", err)
 		}
 
 		// TODO(tj) rename flag to --with-logs or --logs

--- a/function/function_test.go
+++ b/function/function_test.go
@@ -72,25 +72,6 @@ func TestFunction_Open_detectRuntime(t *testing.T) {
 	assert.Nil(t, fn.Open())
 }
 
-func TestFunction_name(t *testing.T) {
-	{
-		fn := &Function{
-			Config: Config{Name: "foo"},
-		}
-
-		assert.Equal(t, "foo", *fn.name())
-	}
-
-	{
-		fn := &Function{
-			Config: Config{Name: "foo"},
-			Prefix: "some",
-		}
-
-		assert.Equal(t, "some_foo", *fn.name())
-	}
-}
-
 func TestFunction_Delete_success(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()


### PR DESCRIPTION
As discussed in #73. This adds the new `nameTemplate` project-level property, with default of: "{{.Project.Name}}_{{.Function.Dir}}". The function's "name" property now overrides this project-level value, which I think is nicer semantically, the name field is useless if it matches the directory.