### PR TITLE
Renamed help -> wiki

### DIFF
--- a/cmd/apex/apex_wiki.go
+++ b/cmd/apex/apex_wiki.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/apex/apex/help"
+	"github.com/apex/apex/wiki"
 	"github.com/apex/log"
 )
 
@@ -21,7 +21,7 @@ const wikiCmdExample = `  Output wiki topics
 
 var wikiCmd = &cobra.Command{
 	Use:     "wiki",
-	Short:   "Output help page pulled from the GitHub wiki",
+	Short:   "Output wiki page pulled from the GitHub wiki",
 	Example: wikiCmdExample,
 	PreRun:  wikiCmdPreRun,
 	Run:     wikiCmdRun,
@@ -43,9 +43,9 @@ func wikiCmdRun(c *cobra.Command, args []string) {
 	var err error
 
 	if lv.topic != "" {
-		err = help.HelpTopic(lv.topic, os.Stdout)
+		err = wiki.WikiTopic(lv.topic, os.Stdout)
 	} else {
-		err = help.HelpTopics(os.Stdout)
+		err = wiki.WikiTopics(os.Stdout)
 	}
 
 	if err != nil {

--- a/wiki/wiki.go
+++ b/wiki/wiki.go
@@ -1,5 +1,5 @@
-// Package help implements a simple GitHub wiki miner and output formatter.
-package help
+// Package wiki implements a simple GitHub wiki miner and output formatter.
+package wiki
 
 import (
 	"fmt"
@@ -12,7 +12,7 @@ import (
 )
 
 // TODO: handle invalid page
-// TODO: HelpTopics could be interactive
+// TODO: WikiTopics could be interactive
 // TODO: ~/.apex.json user config, use here for color mapping etc
 
 // colors.
@@ -25,11 +25,11 @@ const (
 	gray   = 37
 )
 
-// Endpoint used to lookup help information.
+// Endpoint used to lookup wiki information.
 var Endpoint = "https://github.com/apex/apex/wiki"
 
-// Help outputs topic categories.
-func HelpTopics(w io.Writer) error {
+// WikiTopics outputs topic categories.
+func WikiTopics(w io.Writer) error {
 	doc, err := goquery.NewDocument(Endpoint)
 	if err != nil {
 		return err
@@ -43,13 +43,13 @@ func HelpTopics(w io.Writer) error {
 		fmt.Fprintf(w, "  \033[%dm%s\033[0m: %s \n", blue, strs[0], strs[1])
 	})
 
-	fmt.Fprintf(w, "\n  Use `apex help <topic>` to view a topic.\n")
+	fmt.Fprintf(w, "\n  Use `apex wiki <topic>` to view a topic.\n")
 
 	return nil
 }
 
-// HelpTopic outputs topic for the given `topic`.
-func HelpTopic(topic string, w io.Writer) error {
+// WikiTopic outputs topic for the given `topic`.
+func WikiTopic(topic string, w io.Writer) error {
 	doc, err := goquery.NewDocument(fmt.Sprintf("%s/%s", Endpoint, topic))
 	if err != nil {
 		return err


### PR DESCRIPTION
Changed package name and replaced all its content: `help` -> `wiki` (related PR #95)