### PR TITLE
Refactored logs & added -f / --follow support. Closes #57

### DIFF
--- a/cmd/apex/apex_logs.go
+++ b/cmd/apex/apex_logs.go
@@ -49,15 +49,12 @@ func logsCmdRun(c *cobra.Command, args []string) {
 	lv := &logsCmdLocalValues
 	service := cloudwatchlogs.New(pv.session)
 
-	// TODO(tj): refactor logs.Logs to take Project so this hack
-	// can be removed, it'll also make multi-function tailing easier
-	group := fmt.Sprintf("/aws/lambda/%s_%s", pv.project.Name, lv.name)
-
 	l := logs.Logs{
-		LogGroupName:  group,
-		FilterPattern: lv.Filter,
 		Service:       service,
 		Log:           log.Log,
+		Project:       pv.project,
+		FunctionName:  lv.name,
+		FilterPattern: lv.Filter,
 	}
 
 	for event := range l.Tail() {

--- a/cmd/apex/apex_logs.go
+++ b/cmd/apex/apex_logs.go
@@ -3,10 +3,8 @@ package main
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/spf13/cobra"
 
-	"github.com/apex/apex/logs"
 	"github.com/apex/log"
 )
 
@@ -49,14 +47,10 @@ func logsCmdPreRun(c *cobra.Command, args []string) {
 
 func logsCmdRun(c *cobra.Command, args []string) {
 	lv := &logsCmdLocalValues
-	service := cloudwatchlogs.New(pv.session)
 
-	l := logs.Logs{
-		Service:       service,
-		Log:           log.Log,
-		Project:       pv.project,
-		FunctionName:  lv.name,
-		FilterPattern: lv.Filter,
+	l, err := pv.project.Logs(pv.session, lv.name, lv.Filter)
+	if err != nil {
+		log.Fatalf("error: %s", err)
 	}
 
 	if lv.Follow {

--- a/project/project.go
+++ b/project/project.go
@@ -232,6 +232,24 @@ func (p *Project) FunctionNames() (list []string) {
 	return list
 }
 
+// RenderFunctionName returns the computed name for `fn`, using the nameTemplate.
+func (p *Project) RenderFunctionName(fn *function.Function) (string, error) {
+	data := struct {
+		Project  *Project
+		Function *function.Function
+	}{
+		Project:  p,
+		Function: fn,
+	}
+
+	name, err := render(p.nameTemplate, data)
+	if err != nil {
+		return "", err
+	}
+
+	return name, nil
+}
+
 // SetEnv sets environment variable `name` to `value` on every function in project.
 func (p *Project) SetEnv(name, value string) {
 	for _, fn := range p.Functions {
@@ -279,7 +297,7 @@ func (p *Project) loadFunction(name string) (*function.Function, error) {
 		Log:     p.Log,
 	}
 
-	if name, err := p.name(fn); err == nil {
+	if name, err := p.RenderFunctionName(fn); err == nil {
 		fn.FunctionName = name
 	} else {
 		return nil, err
@@ -290,24 +308,6 @@ func (p *Project) loadFunction(name string) (*function.Function, error) {
 	}
 
 	return fn, nil
-}
-
-// name returns the computed name for `fn`, using the nameTemplate.
-func (p *Project) name(fn *function.Function) (string, error) {
-	data := struct {
-		Project  *Project
-		Function *function.Function
-	}{
-		Project:  p,
-		Function: fn,
-	}
-
-	name, err := render(p.nameTemplate, data)
-	if err != nil {
-		return "", err
-	}
-
-	return name, nil
 }
 
 // render returns a string by executing template `t` against the given value `v`.


### PR DESCRIPTION
* Renamed `project.name()` to `project.RenderFunctionName()` (such that `logs` package can call this function)
* Refactored `logs.Logs` to take Project and FunctionName (@tj's TODO comment)
* Fixed bug in group name computation not respecting `nameTemplate` (bug fix)
* Added `-f`/`--follow` flag support to `apex logs`. (doesn't follow by default) (issue #57)