### PR TITLE
Skip persistent value prerun for version and wiki

### DIFF
--- a/cmd/apex/persistent.go
+++ b/cmd/apex/persistent.go
@@ -27,6 +27,10 @@ type PersistentValues struct {
 }
 
 func (pv *PersistentValues) PreRun(c *cobra.Command, args []string) {
+	if c.Name() == "version" || c.Name() == "wiki" {
+		return
+	}
+
 	if l, err := log.ParseLevel(pv.LogLevel); err == nil {
 		log.SetLevel(l)
 	}


### PR DESCRIPTION
Both `apex version` and `apex wiki` do not rely on persistent flags nor `Project`, so we can skip the prerun on persistent values. This allows users run both commands anywhere, even at a non-apex project root.

EDIT: A better way to implement this is overriding `PersistentPreRun` at the command level. I will refactor after PR #103 is merged to the `master` branch.