### PR TITLE
Enabled SilenceErrors option for root command

### DIFF
--- a/cmd/apex/apex.go
+++ b/cmd/apex/apex.go
@@ -7,6 +7,7 @@ import (
 var rootCmd = &cobra.Command{
 	Use:              "apex",
 	PersistentPreRun: pv.PreRun,
+	SilenceErrors:    true,
 }
 
 func init() {


### PR DESCRIPTION
`apex` cmd currently prints error messages twice. `SilenceErrors` is an option to quiet errors down stream. Enabling this option fixes this issue.

--

Before:
```
$ apex foo
Error: unknown command "foo" for "apex"
Run 'apex --help' for usage.
error: unknown command "foo" for "apex"
```
After:
```
$ apex foo
error: unknown command "foo" for "apex"
```