### PR TITLE
Refactoring persistent prerun filter

### DIFF
--- a/cmd/apex/apex.go
+++ b/cmd/apex/apex.go
@@ -6,7 +6,7 @@ import (
 
 var rootCmd = &cobra.Command{
 	Use:              "apex",
-	PersistentPreRun: pv.PreRun,
+	PersistentPreRun: pv.preRun,
 }
 
 func init() {

--- a/cmd/apex/apex_version.go
+++ b/cmd/apex/apex_version.go
@@ -7,9 +7,10 @@ import (
 )
 
 var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Print version of Apex",
-	Run:   versionCmdRun,
+	Use:              "version",
+	Short:            "Print version of Apex",
+	PersistentPreRun: pv.noopRun,
+	Run:              versionCmdRun,
 }
 
 func versionCmdRun(c *cobra.Command, args []string) {

--- a/cmd/apex/apex_wiki.go
+++ b/cmd/apex/apex_wiki.go
@@ -20,11 +20,12 @@ const wikiCmdExample = `  Output wiki topics
   # apex wiki project.json`
 
 var wikiCmd = &cobra.Command{
-	Use:     "wiki [<topic>]",
-	Short:   "Output wiki page pulled from the GitHub wiki",
-	Example: wikiCmdExample,
-	PreRun:  wikiCmdPreRun,
-	Run:     wikiCmdRun,
+	Use:              "wiki [<topic>]",
+	Short:            "Output wiki page pulled from the GitHub wiki",
+	Example:          wikiCmdExample,
+	PersistentPreRun: pv.noopRun,
+	PreRun:           wikiCmdPreRun,
+	Run:              wikiCmdRun,
 }
 
 var wikiCmdLocalValues = WikiCmdLocalValues{}

--- a/cmd/apex/persistent.go
+++ b/cmd/apex/persistent.go
@@ -25,9 +25,7 @@ type PersistentValues struct {
 	project *project.Project
 }
 
-	if c.Name() == "version" || c.Name() == "wiki" {
-		return
-	}
+func (*PersistentValues) noopRun(*cobra.Command, []string) {}
 
 func (pv *PersistentValues) preRun(c *cobra.Command, args []string) {
 	if l, err := log.ParseLevel(pv.LogLevel); err == nil {

--- a/cmd/apex/persistent.go
+++ b/cmd/apex/persistent.go
@@ -25,11 +25,11 @@ type PersistentValues struct {
 	project *project.Project
 }
 
-func (pv *PersistentValues) PreRun(c *cobra.Command, args []string) {
 	if c.Name() == "version" || c.Name() == "wiki" {
 		return
 	}
 
+func (pv *PersistentValues) preRun(c *cobra.Command, args []string) {
 	if l, err := log.ParseLevel(pv.LogLevel); err == nil {
 		log.SetLevel(l)
 	}


### PR DESCRIPTION
This is a follow-up for PR #104. Refactored with a better way that is overriding `PersistentPreRun` at the command level instead of having a filter at the root level. Also renamed a function. No functionality changes by this PR.