### PR TITLE
add upgrade command so apex can update itself. Closes #110

### DIFF
--- a/cmd/apex/apex.go
+++ b/cmd/apex/apex.go
@@ -21,6 +21,7 @@ func init() {
 	rootCmd.AddCommand(buildCmd)
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(wikiCmd)
+	rootCmd.AddCommand(upgradeCmd)
 	rootCmd.AddCommand(versionCmd)
 
 	pf.StringVarP(&pv.Chdir, "chdir", "C", "", "Working directory")

--- a/cmd/apex/apex_delete.go
+++ b/cmd/apex/apex_delete.go
@@ -3,8 +3,8 @@ package main
 import (
 	"fmt"
 
-	"github.com/segmentio/go-prompt"
 	"github.com/spf13/cobra"
+	"github.com/tj/go-prompt"
 
 	"github.com/apex/log"
 )

--- a/cmd/apex/apex_upgrade.go
+++ b/cmd/apex/apex_upgrade.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"github.com/apex/apex/upgrade"
+	"github.com/apex/log"
+	"github.com/spf13/cobra"
+)
+
+var upgradeCmd = &cobra.Command{
+	Use:              "upgrade",
+	Short:            "Ugrade apex to the latest stable release",
+	PersistentPreRun: pv.noopRun,
+	Run:              upgradeCmdRun,
+}
+
+func upgradeCmdRun(c *cobra.Command, args []string) {
+	err := upgrade.Upgrade(version)
+	if err != nil {
+		log.Fatalf("error: %s", err)
+	}
+}

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -48,8 +48,8 @@ func Upgrade(version string) error {
 	}
 
 	// download binary
-	log.Infof("downloading %s", *asset.BrowserDownloadUrl)
-	res, err := http.Get(*asset.BrowserDownloadUrl)
+	log.Infof("downloading %s", *asset.BrowserDownloadURL)
+	res, err := http.Get(*asset.BrowserDownloadURL)
 	if err != nil {
 		return err
 	}

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -1,0 +1,88 @@
+// Package upgrade fetches the latest Apex binary, if any, for the current platform.
+package upgrade
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	"github.com/apex/log"
+	"github.com/google/go-github/github"
+)
+
+// Upgrade the current `version` of apex to the latest.
+func Upgrade(version string) error {
+	log.Infof("current release is v%s", version)
+
+	// fetch releases
+	gh := github.NewClient(nil)
+	releases, _, err := gh.Repositories.ListReleases("apex", "apex", nil)
+	if err != nil {
+		return err
+	}
+
+	// see if it's new
+	latest := releases[0]
+	log.Infof("latest release is %s", *latest.TagName)
+
+	if (*latest.TagName)[1:] == version {
+		log.Infof("you're up to date :)")
+		return nil
+	}
+
+	asset := findAsset(&latest)
+	if asset == nil {
+		return errors.New("cannot find binary for your system")
+	}
+
+	// create tmp file
+	tmpPath := filepath.Join(os.TempDir(), "apex-upgrade")
+	f, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0755)
+	if err != nil {
+		return err
+	}
+
+	// download binary
+	log.Infof("downloading %s", *asset.BrowserDownloadUrl)
+	res, err := http.Get(*asset.BrowserDownloadUrl)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	// copy it down
+	_, err = io.Copy(f, res.Body)
+	if err != nil {
+		return err
+	}
+
+	// replace it
+	cmdPath, err := exec.LookPath("apex")
+	if err != nil {
+		return err
+	}
+
+	log.Infof("replacing %s", cmdPath)
+	err = os.Rename(tmpPath, cmdPath)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("visit https://github.com/apex/apex/releases for the changelog")
+	return nil
+}
+
+// findAsset returns the binary for this platform.
+func findAsset(release *github.RepositoryRelease) *github.ReleaseAsset {
+	for _, asset := range release.Assets {
+		if *asset.Name == fmt.Sprintf("apex_%s_%s", runtime.GOOS, runtime.GOARCH) {
+			return &asset
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Implements `apex upgrade`. We'll need to append .exe for windows I guess, if someone can test that and patch that would be awesome