### PR TITLE
add hook support. Closes #68

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,6 +30,7 @@ Currently supports:
 
 - Supports languages Lambda does not natively support via shim, such as Go
 - Binary install (useful for continuous deployment in CI etc)
+- Hook support for running commands (transpile code, lint, etc)
 - Project level function and resource management
 - Configuration inheritance and overrides
 - Command-line function invocation with JSON streams

--- a/_examples/coffeescript/event.json
+++ b/_examples/coffeescript/event.json
@@ -1,0 +1,3 @@
+{
+  "value": "Tobi the ferret"
+}

--- a/_examples/coffeescript/functions/uppercase/index.cs
+++ b/_examples/coffeescript/functions/uppercase/index.cs
@@ -1,0 +1,5 @@
+
+console.log 'start bar'
+exports.handle = (e, ctx) ->
+  console.log 'processing event: %j', e
+  ctx.succeed value: e.value.toUpperCase()

--- a/_examples/coffeescript/project.json
+++ b/_examples/coffeescript/project.json
@@ -1,0 +1,10 @@
+{
+  "name": "coffeescript",
+  "description": "Coffeescript example using hooks",
+  "role": "arn:aws:iam::293503197324:role/lambda",
+  "runtime": "nodejs",
+  "hooks": {
+    "build": "coffee -cs < index.cs > index.js",
+    "clean": "rm index.js"
+  }
+}

--- a/cmd/apex/apex_build.go
+++ b/cmd/apex/apex_build.go
@@ -44,7 +44,7 @@ func buildCmdRun(c *cobra.Command, args []string) {
 		log.Fatalf("error: %s", err)
 	}
 
-	zip, err := fn.Zip()
+	zip, err := fn.Build()
 	if err != nil {
 		log.Fatalf("error: %s", err)
 	}

--- a/hooks/hooks.go
+++ b/hooks/hooks.go
@@ -1,0 +1,10 @@
+package hooks
+
+// Hooks supported by Apex.
+type Hooks struct {
+	// Build command is run before creating the zip file.
+	Build string `json:"build"`
+
+	// Clean command is run after creating the zip file.
+	Clean string `json:"clean"`
+}

--- a/project/project.go
+++ b/project/project.go
@@ -19,6 +19,7 @@ import (
 	"gopkg.in/validator.v2"
 
 	"github.com/apex/apex/function"
+	"github.com/apex/apex/hooks"
 	"github.com/apex/apex/logs"
 	"github.com/apex/apex/utils"
 	"github.com/apex/log"
@@ -37,13 +38,14 @@ var ErrNotFound = errors.New("project: no function found")
 
 // Config for project.
 type Config struct {
-	Name         string `json:"name" validate:"nonzero"`
-	Description  string `json:"description"`
-	Runtime      string `json:"runtime"`
-	Memory       int64  `json:"memory"`
-	Timeout      int64  `json:"timeout"`
-	Role         string `json:"role"`
-	NameTemplate string `json:"nameTemplate"`
+	Name         string      `json:"name" validate:"nonzero"`
+	Description  string      `json:"description"`
+	Runtime      string      `json:"runtime"`
+	Memory       int64       `json:"memory"`
+	Timeout      int64       `json:"timeout"`
+	Role         string      `json:"role"`
+	NameTemplate string      `json:"nameTemplate"`
+	Hooks        hooks.Hooks `json:"hooks"`
 }
 
 // Project represents zero or more Lambda functions.
@@ -299,10 +301,11 @@ func (p *Project) loadFunction(name string) (*function.Function, error) {
 
 	fn := &function.Function{
 		Config: function.Config{
-			Runtime: p.Config.Runtime,
-			Memory:  p.Config.Memory,
-			Timeout: p.Config.Timeout,
-			Role:    p.Config.Role,
+			Runtime: p.Runtime,
+			Memory:  p.Memory,
+			Timeout: p.Timeout,
+			Role:    p.Role,
+			Hooks:   p.Hooks,
 		},
 		Name:            name,
 		Path:            dir,


### PR DESCRIPTION
Only adds two hooks for now:

- build (pre-zip)
- clean (post-zip)

We can add more on request, pre/post-deploy might be good for linting/testing but I'm using build and clean here so that the `apex build` command works as well

- [ ] update wiki