### PR TITLE
update download reference to 0.5.1

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,7 +8,7 @@ Apex is a small tool for deploying and managing [AWS Lambda](https://aws.amazon.
 Download [binaries](https://github.com/apex/apex/releases):
 
 ```
-curl -sL https://github.com/apex/apex/releases/download/v0.4.1/apex_darwin_amd64 -o /usr/local/bin/apex
+curl -sL https://github.com/apex/apex/releases/download/v0.5.1/apex_darwin_amd64 -o /usr/local/bin/apex
 chmod +x $_
 ```
 


### PR DESCRIPTION
Hey @tj!

I can't seem to find a `latest` url path for release binary downloads. I can imagine keeping this updated in the readme will be pretty annoying / error-prone, so if you have any other ideas for automating bumping it or pointing at a mirror or something lmk and I'm happy to have a go at that too!

Looking forward to making some "real" contributions soon (and using it for some new stuff @ segment!) — awesome progress and momentum so far :clap:! 