### PR TITLE
add support for AWS_PROFILE region from ~/.aws/config

### DIFF
--- a/cmd/apex/root/root.go
+++ b/cmd/apex/root/root.go
@@ -74,12 +74,20 @@ func preRun(c *cobra.Command, args []string) error {
 		log.SetLevel(l)
 	}
 
+	// credential defaults
 	config := aws.NewConfig()
 
+	// explicit profile
 	if profile != "" {
 		config = config.WithCredentials(credentials.NewSharedCredentials("", profile))
 	}
 
+	// support region from ~/.aws/config for AWS_PROFILE
+	if profile == "" {
+		profile = os.Getenv("AWS_PROFILE")
+	}
+
+	// region from ~/.aws/config
 	if region, _ := utils.GetRegion(profile); region != "" {
 		config = config.WithRegion(region)
 	}


### PR DESCRIPTION
this function is getting a little ugly but this adds support for ~/.aws/config's region when using AWS_PROFILE, not just --profile