### PR TITLE
fix missing profile error when AWS_PROFILE not set

### DIFF
--- a/cmd/apex/root/root.go
+++ b/cmd/apex/root/root.go
@@ -84,7 +84,7 @@ func preRun(c *cobra.Command, args []string) error {
 
 	// support region from ~/.aws/config for AWS_PROFILE
 	if profile == "" {
-		profile = os.Getenv("AWS_PROFILE")
+		profile = utils.GetProfile()
 	}
 
 	// region from ~/.aws/config

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -57,7 +57,18 @@ func LoadFiles(root string, ignoredPatterns []string) (files []string, err error
 	return
 }
 
-// GetRegion attempts loading the AWS region from ~/.aws.config.
+// GetProfile attempts to load the profile from AWS_PROFILE otherwise defaults to "default"
+func GetProfile() string {
+	profile := os.Getenv("AWS_PROFILE")
+
+	if profile == "" {
+		return "default"
+	}
+
+	return profile
+}
+
+// GetRegion attempts loading the AWS region from ~/.aws/config.
 func GetRegion(profile string) (string, error) {
 	u, err := user.Current()
 	if err != nil {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,6 +1,7 @@
 package utils_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/apex/apex/utils"
@@ -33,4 +34,17 @@ func Test_ReadIgnoreFile_missing(t *testing.T) {
 func Test_ContainsString(t *testing.T) {
 	assert.True(t, utils.ContainsString([]string{"a", "b"}, "a"))
 	assert.False(t, utils.ContainsString([]string{"a", "b"}, "c"))
+}
+
+func Test_GetProfile_missing(t *testing.T) {
+	os.Unsetenv("AWS_PROFILE")
+	assert.Equal(t, utils.GetProfile(), "default")
+}
+
+func Test_GetProfile_fromENV(t *testing.T) {
+	os.Setenv("AWS_PROFILE", "otherMe")
+
+	assert.Equal(t, utils.GetProfile(), "otherMe")
+
+	os.Unsetenv("AWS_PROFILE")
 }


### PR DESCRIPTION
[fixes #223]

defaults the profile to 'default' per AWS CLI conventions.
