### PR TITLE
refactor root.preRun to support composition

### DIFF
--- a/cmd/apex/root/root.go
+++ b/cmd/apex/root/root.go
@@ -74,9 +74,20 @@ func PreRunNoop(c *cobra.Command, args []string) {
 	// TODO: ew... better way to disable in cobra?
 }
 
-// PreRun sets up global tasks used for most commands, some use PreRunNoop
+// preRun sets up global tasks used for most commands, some use PreRunNoop
 // to remove this default behaviour.
 func preRun(c *cobra.Command, args []string) error {
+	err := Prepare(c, args)
+	if err != nil {
+		return err
+	}
+	return Project.Open()
+}
+
+
+// Prepare handles the global CLI flags and shared functionality without
+// the assumption that a Project has already been initialized.
+func Prepare(c *cobra.Command, args []string) error {
 	if l, err := log.ParseLevel(logLevel); err == nil {
 		log.SetLevel(l)
 	}
@@ -119,6 +130,7 @@ func preRun(c *cobra.Command, args []string) error {
 			return err
 		}
 	}
-
-	return Project.Open()
+	return nil
 }
+
+


### PR DESCRIPTION
The root.preRun func assigned to ```rootCmd.PersistentPreRunE``` relies
on Project.Open(), which assumes all child commands will want to operate
on an existing Project.

While it's no big deal to assign root.PreRunNoop, that actually seems to
mess with a couple of the truly shared global flag handlers.
For example, ```log-level```, ```chdir``` and ```dry-run``` are handled in the
```root.preRun``` right now. This makes the ```PreRunNoop``` trick come
with the odd side-effect of those flags being unhandled.

The Cobra ```command.SetGlobalNormalizationFunc``` might be abused to handle
flag-triggered actions, but that seems dangerous as well. :skull:

As a starting point, this PR separates out the ```Project.Open()``` and the other
calls, which makes it easier to compose a custom ```PersistentPreRunE``` in
child commands that don't assume a Project already exists.

This is necessary for the work I'm doing today on #229 (which will come in a different PR).

Any better ways of handling this would be awesome. Decomposing the flag-triggered stuff
even further might be good to consider.