### PR TITLE
removes short flag for the AWS credentials file

### DIFF
--- a/cmd/apex/root/root.go
+++ b/cmd/apex/root/root.go
@@ -64,7 +64,7 @@ func init() {
 	f.StringSliceVarP(&Env, "env", "e", nil, "Environment variable")
 	f.StringVarP(&logLevel, "log-level", "l", "info", "Log severity level")
 	f.StringVarP(&profile, "profile", "p", "", "AWS profile to use")
-	f.StringVarP(&creds, "credentials", "c", "", "AWS credentials file to use (~/.aws/credentials)")
+	f.StringVar(&creds, "credentials", "", "AWS credentials file to use (~/.aws/credentials)")
 
 	Command.SetHelpTemplate("\n" + Command.HelpTemplate())
 }


### PR DESCRIPTION
The ```-c``` short flag caused a runtime panic with the deploy command, as it had its own ```-c``` flag. This causes Cobra to :fire: :scream: :fire:

This PR removes the short flag, so the cli now just accepts ```--credentials foo/credzz``` rather than also having a short flag.