### PR TITLE
fix loading region from default profile

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -82,7 +82,7 @@ func GetRegion(profile string) (string, error) {
 	}
 
 	sectionName := "default"
-	if profile != "" {
+	if profile != "" && profile != "default" {
 		sectionName = fmt.Sprintf("profile %s", profile)
 	}
 


### PR DESCRIPTION
default sections header is 
```
[default]
```

not 

```
[profile default]
```

 http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html