### PR TITLE
fixes shadowed root.Config variable

### DIFF
--- a/cmd/apex/root/root.go
+++ b/cmd/apex/root/root.go
@@ -93,7 +93,7 @@ func Prepare(c *cobra.Command, args []string) error {
 	}
 
 	// credential defaults
-	Config := aws.NewConfig()
+	Config = aws.NewConfig()
 
 	// explicit profile
 	if profile != "" {


### PR DESCRIPTION
I came across this shadowed ```Config``` variable when trying to inspect ```root.Config```
