### PR TITLE
add zip compression. Closes #263

### DIFF
--- a/function/function.go
+++ b/function/function.go
@@ -3,6 +3,7 @@ package function
 
 import (
 	"bytes"
+	"compress/flate"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -455,7 +456,7 @@ func (f *Function) Build() (io.Reader, error) {
 	f.Log.Debugf("creating build")
 
 	buf := new(bytes.Buffer)
-	zip := archive.NewZipWriter(buf)
+	zip := archive.NewCompressedZipWriter(buf, flate.DefaultCompression)
 
 	if err := f.hookBuild(zip); err != nil {
 		return nil, err


### PR DESCRIPTION
This change works the same on both 1.5 and 1.6. If we would like to change compression level we need to build in 1.6. On 1.5 level param is ignored and `flate.DefaultCompression` is used.