### PR TITLE
refactor env flag; moved to deploy command

### DIFF
--- a/cmd/apex/deploy/deploy.go
+++ b/cmd/apex/deploy/deploy.go
@@ -9,6 +9,9 @@ import (
 	"github.com/apex/apex/cmd/apex/root"
 )
 
+// env supplied.
+var env []string
+
 // concurrency of deploys.
 var concurrency int
 
@@ -35,6 +38,7 @@ func init() {
 	root.Register(Command)
 
 	f := Command.Flags()
+	f.StringSliceVarP(&env, "env", "e", nil, "Environment variable")
 	f.IntVarP(&concurrency, "concurrency", "c", 5, "Concurrent deploys")
 }
 
@@ -47,7 +51,7 @@ func run(c *cobra.Command, args []string) error {
 		return err
 	}
 
-	for _, s := range root.Env {
+	for _, s := range env {
 		parts := strings.Split(s, "=")
 		root.Project.Setenv(parts[0], parts[1])
 	}

--- a/cmd/apex/root/root.go
+++ b/cmd/apex/root/root.go
@@ -30,9 +30,6 @@ var creds string
 // profile for AWS creds.
 var profile string
 
-// Env supplied.
-var Env []string
-
 // Session instance.
 var Session *session.Session
 
@@ -58,7 +55,6 @@ func init() {
 
 	f.StringVarP(&chdir, "chdir", "C", "", "Working directory")
 	f.BoolVarP(&dryRun, "dry-run", "D", false, "Perform a dry-run")
-	f.StringSliceVarP(&Env, "env", "e", nil, "Environment variable")
 	f.StringVarP(&logLevel, "log-level", "l", "info", "Log severity level")
 	f.StringVarP(&profile, "profile", "p", "", "AWS profile to use")
 	f.StringVar(&creds, "credentials", "", "AWS credentials file to use (~/.aws/credentials)")


### PR DESCRIPTION
It's used only in deploy. Less noise in `apex help`.