### PR TITLE
add global flag to prevent colorizing output. Closes #293

### DIFF
--- a/cmd/apex/list/list.go
+++ b/cmd/apex/list/list.go
@@ -69,7 +69,11 @@ func outputTFvars() {
 func outputList() {
 	fmt.Println()
 	for _, fn := range root.Project.Functions {
-		fmt.Printf("  \033[%dm%s\033[0m\n", colors.Blue, fn.Name)
+		color := colors.Blue
+		if noColor, _ := root.Command.PersistentFlags().GetBool("no-color"); noColor {
+			color = colors.None
+		}
+		fmt.Printf("  \033[%dm%s\033[0m\n", color, fn.Name)
 		if fn.Description != "" {
 			fmt.Printf("    description: %v\n", fn.Description)
 		}

--- a/cmd/apex/metrics/metrics.go
+++ b/cmd/apex/metrics/metrics.go
@@ -69,9 +69,14 @@ func run(c *cobra.Command, args []string) error {
 
 	fmt.Println()
 	for _, fn := range root.Project.Functions {
+		color := colors.Blue
+		if noColor, _ := root.Command.PersistentFlags().GetBool("no-color"); noColor {
+			color = colors.None
+		}
+
 		fnMetrics := aggregated[fn.FunctionName]
 
-		fmt.Printf("  \033[%dm%s\033[0m\n", colors.Blue, fn.Name)
+		fmt.Printf("  \033[%dm%s\033[0m\n", color, fn.Name)
 		fmt.Printf("    invocations: %v\n", fnMetrics.Invocations)
 		fmt.Printf("    duration: %vms\n", fnMetrics.Duration)
 		fmt.Printf("    throttles: %v\n", fnMetrics.Throttles)

--- a/cmd/apex/root/root.go
+++ b/cmd/apex/root/root.go
@@ -30,6 +30,9 @@ var creds string
 // profile for AWS creds.
 var profile string
 
+// colorize output.
+var noColor bool
+
 // Session instance.
 var Session *session.Session
 
@@ -58,6 +61,7 @@ func init() {
 	f.StringVarP(&logLevel, "log-level", "l", "info", "Log severity level")
 	f.StringVarP(&profile, "profile", "p", "", "AWS profile to use")
 	f.StringVar(&creds, "credentials", "", "AWS credentials file to use (~/.aws/credentials)")
+	f.BoolVar(&noColor, "no-color", false, "Do not colorize output")
 
 	Command.SetHelpTemplate("\n" + Command.HelpTemplate())
 }


### PR DESCRIPTION
Colorization is only done in a couple spots right now, but ultimately it would be useful to have something like a `Printer` class for output with methods like `.Blue`, `.Red`, etc. If this flag is set, the `Printer` could be an implementation that doesn't actually colorize the output for these methods.