### PR TITLE
add deploy, rollback, and invoke --alias support. Closes #7

### DIFF
--- a/_examples/node/project.json
+++ b/_examples/node/project.json
@@ -1,7 +1,7 @@
 {
   "name": "node",
   "description": "Node.js example project",
-  "role": "arn:aws:iam::293503197324:role/lambda",
+  "role": "arn:aws:iam::293503197324:role/lambda_function",
   "environment": {
     "LOGGLY_TOKEN": "some token defined in project.json"
   }

--- a/cmd/apex/deploy/deploy.go
+++ b/cmd/apex/deploy/deploy.go
@@ -15,12 +15,18 @@ var env []string
 // concurrency of deploys.
 var concurrency int
 
+// alias.
+var alias string
+
 // example output.
 const example = `  Deploy all functions
   $ apex deploy
 
   Deploy specific functions
   $ apex deploy foo bar
+
+  Deploy canary alias
+  $ apex deploy foo --alias canary
 
   Deploy functions in a different project
   $ apex deploy -C ~/dev/myapp`
@@ -39,12 +45,15 @@ func init() {
 
 	f := Command.Flags()
 	f.StringSliceVarP(&env, "env", "e", nil, "Environment variable")
+	f.StringVarP(&alias, "alias", "a", "current", "Function alias")
 	f.IntVarP(&concurrency, "concurrency", "c", 5, "Concurrent deploys")
 }
 
 // Run command.
 func run(c *cobra.Command, args []string) error {
 	root.Project.Concurrency = concurrency
+	root.Project.Alias = alias
+
 	c.Root().PersistentFlags().Lookup("name string")
 
 	if err := root.Project.LoadFunctions(args...); err != nil {

--- a/cmd/apex/invoke/invoke.go
+++ b/cmd/apex/invoke/invoke.go
@@ -15,6 +15,9 @@ import (
 	"github.com/apex/apex/cmd/apex/root"
 )
 
+// alias.
+var alias string
+
 // includeLogs in output.
 var includeLogs bool
 
@@ -23,7 +26,10 @@ var name string
 
 // example output.
 const example = `  Invoke a function with input json
-  $ apex invoke foo < request.json`
+  $ apex invoke foo < request.json
+
+  Invoke canary alias
+  $ apex invoke foo < request.json --alias canary`
 
 // Command config.
 var Command = &cobra.Command{
@@ -40,6 +46,7 @@ func init() {
 
 	f := Command.Flags()
 	f.BoolVarP(&includeLogs, "logs", "L", false, "Print logs")
+	f.StringVarP(&alias, "alias", "a", "current", "Function alias")
 }
 
 // PreRun errors if the name argument is missing.
@@ -55,6 +62,8 @@ func preRun(c *cobra.Command, args []string) error {
 // Run command.
 func run(c *cobra.Command, args []string) error {
 	dec := json.NewDecoder(input())
+
+	root.Project.Alias = alias
 
 	if err := root.Project.LoadFunctions(name); err != nil {
 		return err

--- a/cmd/apex/rollback/rollback.go
+++ b/cmd/apex/rollback/rollback.go
@@ -9,6 +9,9 @@ import (
 	"github.com/apex/apex/cmd/apex/root"
 )
 
+// alias.
+var alias string
+
 // name of function.
 var name string
 
@@ -18,6 +21,9 @@ var version string
 // example output.
 const example = `  Rollback a function to the previous version
   $ apex rollback foo
+
+  Rollback canary alias
+  $ apex rollback foo --alias canary
 
   Rollback a function to the specified version
   $ apex rollback bar -v 3`
@@ -36,6 +42,7 @@ func init() {
 	root.Register(Command)
 
 	f := Command.Flags()
+	f.StringVarP(&alias, "alias", "a", "current", "Function alias")
 	f.StringVarP(&version, "version", "v", "", "version to which rollback is done")
 }
 
@@ -51,6 +58,8 @@ func preRun(c *cobra.Command, args []string) error {
 
 // Run command.
 func run(c *cobra.Command, args []string) error {
+	root.Project.Alias = alias
+
 	if err := root.Project.LoadFunctions(name); err != nil {
 		return err
 	}

--- a/function/function_test.go
+++ b/function/function_test.go
@@ -121,6 +121,7 @@ func TestFunction_Rollback_GetAlias_failed(t *testing.T) {
 
 	fn := &function.Function{
 		FunctionName: "testfn",
+		Alias:        "current",
 		Service:      serviceMock,
 		Log:          log.Log,
 	}
@@ -141,6 +142,7 @@ func TestFunction_Rollback_ListVersions_failed(t *testing.T) {
 
 	fn := &function.Function{
 		FunctionName: "testfn",
+		Alias:        "current",
 		Service:      serviceMock,
 		Log:          log.Log,
 	}
@@ -161,6 +163,7 @@ func TestFunction_Rollback_fewVersions(t *testing.T) {
 
 	fn := &function.Function{
 		FunctionName: "testfn",
+		Alias:        "current",
 		Service:      serviceMock,
 		Log:          log.Log,
 	}
@@ -191,6 +194,7 @@ func TestFunction_Rollback_previousVersion(t *testing.T) {
 
 	fn := &function.Function{
 		FunctionName: "testfn",
+		Alias:        "current",
 		Service:      serviceMock,
 		Log:          log.Log,
 	}
@@ -221,6 +225,7 @@ func TestFunction_Rollback_latestVersion(t *testing.T) {
 
 	fn := &function.Function{
 		FunctionName: "testfn",
+		Alias:        "current",
 		Service:      serviceMock,
 		Log:          log.Log,
 	}
@@ -246,6 +251,7 @@ func TestFunction_Rollback_UpdateAlias_failed(t *testing.T) {
 
 	fn := &function.Function{
 		FunctionName: "testfn",
+		Alias:        "current",
 		Service:      serviceMock,
 		Log:          log.Log,
 	}
@@ -266,6 +272,7 @@ func TestFunction_RollbackVersion_GetAlias_failed(t *testing.T) {
 
 	fn := &function.Function{
 		FunctionName: "testfn",
+		Alias:        "current",
 		Service:      serviceMock,
 		Log:          log.Log,
 	}
@@ -307,6 +314,7 @@ func TestFunction_RollbackVersion_success(t *testing.T) {
 
 	fn := &function.Function{
 		FunctionName: "testfn",
+		Alias:        "current",
 		Service:      serviceMock,
 		Log:          log.Log,
 	}

--- a/project/project.go
+++ b/project/project.go
@@ -53,6 +53,7 @@ type Config struct {
 type Project struct {
 	Config
 	Path         string
+	Alias        string
 	Concurrency  int
 	Log          log.Interface
 	Service      lambdaiface.LambdaAPI
@@ -285,6 +286,7 @@ func (p *Project) LoadFunctionByPath(name, path string) (*function.Function, err
 		Service:    p.Service,
 		Log:        p.Log,
 		IgnoreFile: p.IgnoreFile,
+		Alias:      p.Alias,
 	}
 
 	if name, err := p.name(fn); err == nil {


### PR DESCRIPTION
Review please!

Adds `--alias name` to rollback, deploy, and invoke so that you can launch canary functions etc.

I'll squash that other lame commit after.