### PR TITLE
fix AWS config precedence

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -56,17 +56,6 @@ func LoadFiles(root string, ignoreFile []byte) (files []string, err error) {
 	return
 }
 
-// GetProfile attempts to load the profile from AWS_PROFILE otherwise defaults to "default"
-func GetProfile() string {
-	profile := os.Getenv("AWS_PROFILE")
-
-	if profile == "" {
-		return "default"
-	}
-
-	return profile
-}
-
 // GetRegion attempts loading the AWS region from ~/.aws/config.
 func GetRegion(profile string) (string, error) {
 	home, err := homedir.Dir()

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,7 +1,6 @@
 package utils_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/apex/apex/utils"
@@ -34,17 +33,4 @@ func Test_ReadIgnoreFile_missing(t *testing.T) {
 func Test_ContainsString(t *testing.T) {
 	assert.True(t, utils.ContainsString([]string{"a", "b"}, "a"))
 	assert.False(t, utils.ContainsString([]string{"a", "b"}, "c"))
-}
-
-func Test_GetProfile_missing(t *testing.T) {
-	os.Unsetenv("AWS_PROFILE")
-	assert.Equal(t, utils.GetProfile(), "default")
-}
-
-func Test_GetProfile_fromENV(t *testing.T) {
-	os.Setenv("AWS_PROFILE", "otherMe")
-
-	assert.Equal(t, utils.GetProfile(), "otherMe")
-
-	os.Unsetenv("AWS_PROFILE")
 }


### PR DESCRIPTION
removed cred file thing because AWS already has AWS_SHARED_CREDENTIALS_FILE (cant see this being useful anyway) and added --region because screw env vars.

hard to see what's going on in the diff but now it's:

```go
	// profile from flag, env, "default"
	if profile == "" {
		profile = os.Getenv("AWS_PROFILE")
		if profile == "" {
			profile = "default"
		}
	}

	// the default SharedCredentialsProvider checks the env
	os.Setenv("AWS_PROFILE", profile)

	// region from flag, env, file
	if region == "" {
		region = os.Getenv("AWS_REGION")
		if region == "" {
			region, _ = utils.GetRegion(profile)
		}
	}

	if region != "" {
		Config = Config.WithRegion(region)
	}
```

their code is confusing and hard to grok with all these abstractions, if we got rid of ~/.aws/config we wouldn't have to do this dance at all we'd just set AWS_PROFILE and WithRegion