### PR TITLE
Adding java-jar plugin

### DIFF
--- a/cmd/apex/main.go
+++ b/cmd/apex/main.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/apex/apex/plugins/golang"
 	_ "github.com/apex/apex/plugins/hooks"
 	_ "github.com/apex/apex/plugins/inference"
+	_ "github.com/apex/apex/plugins/java"
 	_ "github.com/apex/apex/plugins/nodejs"
 	_ "github.com/apex/apex/plugins/python"
 	_ "github.com/apex/apex/plugins/shim"

--- a/docs/java.md
+++ b/docs/java.md
@@ -1,7 +1,6 @@
 # Requirements
 
-Apex expects `pom.xml` file to be in function directory. Requirements for `pom.xml` to work with apex:
+Apex expects that your JVM project generate a fat jar, with all dependencies included. Requirements for your jar to work with Apex:
 
-- `mvn package` produces valid jar
-- `jar.finalName` prop has to set name jar name
+- `apex.jar` has to be in either `target/` or `build/libs/`
 - has AWS Lambda dependencies (`com.amazonaws.aws-lambda-java-core`)

--- a/plugins/inference/inference.go
+++ b/plugins/inference/inference.go
@@ -15,10 +15,11 @@ import (
 func init() {
 	function.RegisterPlugin("inference", &Plugin{
 		Files: map[string]string{
-			"main.py":  python.Runtime,
-			"index.js": nodejs.Runtime,
-			"main.go":  golang.Runtime,
-			"pom.xml":  java.Runtime,
+			"main.py":             python.Runtime,
+			"index.js":            nodejs.Runtime,
+			"main.go":             golang.Runtime,
+			"target/apex.jar":     java.Runtime,
+			"build/libs/apex.jar": java.Runtime,
 		},
 	})
 }


### PR DESCRIPTION
Adds a `javajar` plugin, as discussed in #300. 

Searches common build artifact paths for a jar name by `apex.jar`. I think I might change the findJar function to find by JAR classifier instead of forcing the JAR to be a static name. Example: `apex.jar` vs `artifact-1.0.0-SNAPSHOT-apex.jar`. Thoughts?