### PR TITLE
fix: api-gateway example Internal server error

### DIFF
--- a/_examples/api-gateway/infrastructure/dev/api-gateway.tf
+++ b/_examples/api-gateway/infrastructure/dev/api-gateway.tf
@@ -23,6 +23,9 @@ resource "aws_api_gateway_method_response" "200" {
   resource_id = "${aws_api_gateway_resource.Hello.id}"
   http_method = "${aws_api_gateway_method.HelloGet.http_method}"
   status_code = "200"
+  response_models = {
+    "application/json" = "Empty"
+  }
 }
 
 resource "aws_api_gateway_integration_response" "Hello" {


### PR DESCRIPTION
When API Gateway method response status code is 200, and has not define model, it will be response 500 error like:

  Execution failed due to configuration error: Output mapping refers to an invalid method response: 200
  Method completed with status: 500

So I added the default model "Empty" to resolve this issue.