### PR TITLE
add nodejs 4.3.2 support. Closes #356

### DIFF
--- a/plugins/inference/inference.go
+++ b/plugins/inference/inference.go
@@ -16,7 +16,7 @@ func init() {
 	function.RegisterPlugin("inference", &Plugin{
 		Files: map[string]string{
 			"main.py":             python.Runtime,
-			"index.js":            nodejs.Runtime,
+			"index.js":            nodejs.Runtime43,
 			"main.go":             golang.Runtime,
 			"target/apex.jar":     java.Runtime,
 			"build/libs/apex.jar": java.Runtime,


### PR DESCRIPTION
Worth to mention that updating nodejs version on already deployed function will have no effect. `apex delete` is needed before. 