### PR TITLE
Fixes #382 - missing defaultEnvironment in project.json

### DIFF
--- a/boot/boot.go
+++ b/boot/boot.go
@@ -24,7 +24,7 @@ var projectConfig = `
   "memory": 128,
   "timeout": 5,
   "role": "%s",
-	"defaultEnvironment": "dev",
+  "defaultEnvironment": "dev",
   "environment": {}
 }`
 
@@ -34,6 +34,7 @@ var projectConfigWithoutRole = `
   "description": "%s",
   "memory": 128,
   "timeout": 5,
+  "defaultEnvironment": "dev",
   "environment": {}
 }`
 


### PR DESCRIPTION
This PR is a simple fix to address #382 - which results in a missing ```defaultEnvironment``` key in ```project.json``` if you don't have an IAM role defined when running the bootstrapping ```init``` command.

I will submit a separate issue & PR to simplify how boot.go handles the logic, but that isn't required to patch the bug, so this simple patch fixes that first 💋

(closed prior PR due to messy commit history)