### PR TITLE
Fixes issue 405 - adds ability to disable version cleanup

### DIFF
--- a/function/function.go
+++ b/function/function.go
@@ -613,10 +613,9 @@ func (f *Function) versions() ([]*lambda.FunctionConfiguration, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	versions := list.Versions
-	if *versions[0].Version == "$LATEST" {
-		versions = versions[1:] // remove $LATEST
-	}
+	versions = versions[1:] // remove $LATEST
 
 	return versions, nil
 }

--- a/function/function_internal_test.go
+++ b/function/function_internal_test.go
@@ -1,0 +1,92 @@
+package function
+
+import (
+	"testing"
+	"github.com/apex/log"
+	"github.com/apex/log/handlers/discard"
+	"github.com/stretchr/testify/assert"
+	"github.com/golang/mock/gomock"
+	"github.com/apex/apex/mock"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/lambda"
+)
+
+func init() {
+	log.SetHandler(discard.New())
+}
+
+var cannedVersions = []*lambda.FunctionConfiguration{
+	&lambda.FunctionConfiguration{Version: aws.String("1")},
+	&lambda.FunctionConfiguration{Version: aws.String("2")},
+	&lambda.FunctionConfiguration{Version: aws.String("3")},
+	&lambda.FunctionConfiguration{Version: aws.String("4")},
+	&lambda.FunctionConfiguration{Version: aws.String("5")},
+	&lambda.FunctionConfiguration{Version: aws.String("6")},
+	&lambda.FunctionConfiguration{Version: aws.String("7")},
+	&lambda.FunctionConfiguration{Version: aws.String("8")},
+	&lambda.FunctionConfiguration{Version: aws.String("9")},
+	&lambda.FunctionConfiguration{Version: aws.String("10")},
+	&lambda.FunctionConfiguration{Version: aws.String("11")},
+}
+
+func TestFunction_versionsToCleanup_all(t *testing.T) {
+	retainedVersions := -1
+	versions, err := versionsToDelete(t, retainedVersions)
+
+	assert.Len(t, versions, 11)
+	assert.Nil(t, err)
+}
+
+func TestFunction_versionsToCleanup_default(t *testing.T) {
+	retainedVersions := 0
+	versions, err := versionsToDelete(t, retainedVersions)
+
+	assert.Len(t, versions, 1)
+	assert.Nil(t, err)
+}
+
+func TestFunction_versionsToCleanup_two(t *testing.T) {
+	retainedVersions := 2
+	versions, err := versionsToDelete(t, retainedVersions)
+
+	assert.Len(t, versions, 9)
+	assert.Nil(t, err)
+}
+
+func TestFunction_versionsToCleanup_none(t *testing.T) {
+	retainedVersions := 11
+	versions, err := versionsToDelete(t, retainedVersions)
+
+	assert.Len(t, versions, 0)
+	assert.Nil(t, err)
+}
+
+func versionsToDelete(t *testing.T, configVersions int) ([]*lambda.FunctionConfiguration, error) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	serviceMock := mock_lambdaiface.NewMockLambdaAPI(mockCtrl)
+
+	serviceMock.EXPECT().ListVersionsByFunction(gomock.Any()).Return(&lambda.ListVersionsByFunctionOutput{Versions: cannedVersions}, nil)
+
+	fn := &Function{
+		Config: Config{
+			Memory:  128,
+			Timeout: 3,
+			Role:    "iamrole",
+			RetainedVersions: configVersions,
+		},
+		Path: "_fixtures/nodejsDefaultFile",
+		Name: "test",
+		Log:  log.Log,
+		Service: serviceMock,
+	}
+
+	err := fn.Open()
+	if err != nil {
+		return nil, err
+	}
+
+	return fn.versionsToCleanup()
+
+}
+

--- a/function/function_internal_test.go
+++ b/function/function_internal_test.go
@@ -16,6 +16,7 @@ func init() {
 }
 
 var cannedVersions = []*lambda.FunctionConfiguration{
+	&lambda.FunctionConfiguration{Version: aws.String("$LATEST")},
 	&lambda.FunctionConfiguration{Version: aws.String("1")},
 	&lambda.FunctionConfiguration{Version: aws.String("2")},
 	&lambda.FunctionConfiguration{Version: aws.String("3")},

--- a/project/project.go
+++ b/project/project.go
@@ -83,7 +83,7 @@ func (p *Project) defaults() {
 	}
 
 	if p.RetainedVersions == 0 {
-		p.RetainedVersions = 10
+		p.RetainedVersions = function.DefaultRetainedVersions
 	}
 }
 


### PR DESCRIPTION
This addresses the issue #405 - using a value of ```-1``` for ```RetainedVersions``` to disable the cleanup of deployed versions.

I'm opening a related issue around refactoring this behavior, but this one seemed clear. 

I also added some tests that allow us to test the private methods of the ```function``` package. If someone wants to do this in a better way, please modify or make suggestions! I just needed to get some coverage in for this logic since it's sort of... odd.

Finally, I added a default ```RetainedVersions``` value as a ```const``` in ```function``` and will separately propose that we do the same for a couple of ```const``` values in ```project```

🔬 