### PR TITLE
fix panic when 'apex invoke -L' throws an error

### DIFF
--- a/cmd/apex/invoke/invoke.go
+++ b/cmd/apex/invoke/invoke.go
@@ -97,7 +97,7 @@ func run(c *cobra.Command, args []string) error {
 			reply, logs, err = fn.Invoke(v, nil)
 		}
 
-		if includeLogs {
+		if includeLogs && logs != nil {
 			io.Copy(os.Stderr, logs)
 		}
 


### PR DESCRIPTION
`fn.Invoke` returns `nil` for logs when an error occurs