### PR TITLE
add aliases to apex list. Closes #430

### DIFF
--- a/cmd/apex/list/list.go
+++ b/cmd/apex/list/list.go
@@ -78,7 +78,7 @@ func outputTFvars() {
 func outputList() {
 	fmt.Println()
 	for _, fn := range root.Project.Functions {
-		config, err := fn.GetConfigCurrent()
+		_, err := fn.GetConfigCurrent()
 
 		if awserr, ok := err.(awserr.Error); ok && awserr.Code() == "ResourceNotFoundException" {
 			fmt.Printf("  \033[%dm%s\033[0m (not deployed) \n", colors.Blue, fn.Name)
@@ -116,7 +116,6 @@ func outputList() {
 			aliases = "<none>"
 		}
 		fmt.Printf("    aliases: %s\n", aliases)
-		fmt.Printf("    current version: %s\n", *config.Configuration.Version)
 		fmt.Println()
 	}
 }

--- a/cmd/apex/list/list.go
+++ b/cmd/apex/list/list.go
@@ -100,8 +100,23 @@ func outputList() {
 			continue // ignore
 		}
 
-		fmt.Printf("    current version: %s\n", *config.Configuration.Version)
+		aliaslist, err := fn.GetAliases()
+		if err != nil {
+			continue
+		}
 
+		var aliases string
+		for index, alias := range aliaslist.Aliases {
+			if index > 0 {
+				aliases += ", "
+			}
+			aliases += fmt.Sprintf("%s@v%s", *alias.Name, *alias.FunctionVersion)
+		}
+		if aliases == "" {
+			aliases = "<none>"
+		}
+		fmt.Printf("    aliases: %s\n", aliases)
+		fmt.Printf("    current version: %s\n", *config.Configuration.Version)
 		fmt.Println()
 	}
 }

--- a/docs/list.md
+++ b/docs/list.md
@@ -14,7 +14,7 @@ $ apex list
     timeout: 5s
     role: arn:aws:iam::293503197324:role/lambda
     handler: index.handle
-    current version: 3
+    aliases: current@v3, foo@v4
 
   foo
     runtime: nodejs
@@ -22,7 +22,7 @@ $ apex list
     timeout: 10s
     role: arn:aws:iam::293503197324:role/lambda
     handler: index.handle
-    current version: 12
+    aliases: current@v12
 ```
 
 Terraform vars output:

--- a/function/function.go
+++ b/function/function.go
@@ -384,6 +384,14 @@ func (f *Function) CreateOrUpdateAlias(alias, version string) error {
 	return nil
 }
 
+// GetAliases fetches a list of aliases for the function.
+func (f *Function) GetAliases() (*lambda.ListAliasesOutput, error) {
+	f.Log.Debug("fetching aliases")
+	return f.Service.ListAliases(&lambda.ListAliasesInput{
+		FunctionName: &f.FunctionName,
+	})
+}
+
 // Invoke the remote Lambda function, returning the response and logs, if any.
 func (f *Function) Invoke(event, context interface{}) (reply, logs io.Reader, err error) {
 	eventBytes, err := json.Marshal(event)


### PR DESCRIPTION
```
$ apex list

  test
    runtime: nodejs
    memory: 128mb
    timeout: 5s
    role: arn:aws:iam::123412341234:role/MyRole
    handler: index.handle
    aliases: current@v6, foo@v5
    current version: 6
```

I wasn't too sure how to present the aliases; this seems OK, but showing the `current` alias kinda duplicates the information from `current version:` on the next line. let me know what you think :)

