### PR TITLE
add aws-sdk workaround to webpack example

### DIFF
--- a/_examples/babel-webpack/webpack.config.js
+++ b/_examples/babel-webpack/webpack.config.js
@@ -8,6 +8,12 @@ module.exports = {
     filename: 'index.js',
     libraryTarget: 'commonjs2'
   },
+  externals: {
+    // aws-sdk does not (currently) build correctly with webpack. However,
+    // Lambda includes it in its environment, so omit it from the bundle.
+    // See: https://github.com/apex/apex/issues/217#issuecomment-194247472
+    'aws-sdk': 'aws-sdk'
+  },
   module: {
     loaders: [
       {


### PR DESCRIPTION
Using aws-sdk in the context of Node-based Lambda functions is common, so
including this will save a headache for the next person.