### PR TITLE
expose function-specific role to infra

### DIFF
--- a/infra/infra.go
+++ b/infra/infra.go
@@ -67,6 +67,11 @@ func (p *Proxy) functionVars() (args []string) {
 
 		args = append(args, "-var")
 		args = append(args, fmt.Sprintf("apex_function_%s=%s", fn.Name, *config.Configuration.FunctionArn))
+
+		if fn.Role != "" {
+			args = append(args, "-var")
+			args = append(args, fmt.Sprintf("apex_function_%s_role=%s", fn.Name, fn.Role))
+		}
 	}
 
 	return args


### PR DESCRIPTION
Function-specific roles are currently not passed to terraform -- only the project role is passed (if it exists).

Now, `apex_function_$FNNAME_role` will be passed with the corresponding function role. This is also the project role, if it is available.