### PR TITLE
Building fails java-example - hook and runtime missing

### DIFF
--- a/_examples/java/functions/with-pom/function.json
+++ b/_examples/java/functions/with-pom/function.json
@@ -1,4 +1,9 @@
 {
   "description": "Java example function with existing pom.xml",
-  "handler": "lambda.Example::handler"
+  "handler": "lambda.Example::handler",
+  "runtime": "java",
+  "hooks": {
+    "build": "mvn package",
+    "clean": "mvn clean"
+  }
 }


### PR DESCRIPTION
Just a minor fix that makes sure building actually works.

