### PR TITLE
Updated runtime for Golang since AWS no longer supports nodejs 0.10

### DIFF
--- a/plugins/golang/golang.go
+++ b/plugins/golang/golang.go
@@ -6,14 +6,14 @@ import (
 	"github.com/apex/apex/plugins/nodejs"
 )
 
-func init() {
-	function.RegisterPlugin("golang", &Plugin{})
-}
-
 const (
 	// Runtime name used by Apex
 	Runtime = "golang"
 )
+
+func init() {
+	function.RegisterPlugin(Runtime, &Plugin{})
+}
 
 // Plugin implementation.
 type Plugin struct{}
@@ -29,7 +29,7 @@ func (p *Plugin) Open(fn *function.Function) error {
 	}
 
 	fn.Shim = true
-	fn.Runtime = nodejs.Runtime
+	fn.Runtime = nodejs.Runtime43
 
 	if fn.Hooks.Clean == "" {
 		fn.Hooks.Clean = "rm -f main"


### PR DESCRIPTION
Just changed runtime string only not stubs(index.js, ...)

When I run

> apex deploy

It shows up today. So I just did

> InvalidParameterValueException: The runtime parameter of nodejs is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs4.3) while creating or updating functions.
