### PR TITLE
fix lambda runtime for "golang" functions to "nodejs4.3". Closes #635

### DIFF
--- a/plugins/golang/golang.go
+++ b/plugins/golang/golang.go
@@ -29,7 +29,7 @@ func (p *Plugin) Open(fn *function.Function) error {
 	}
 
 	fn.Shim = true
-	fn.Runtime = nodejs.Runtime
+	fn.Runtime = nodejs.Runtime43
 
 	if fn.Hooks.Clean == "" {
 		fn.Hooks.Clean = "rm -f main"


### PR DESCRIPTION
Without this fix, deploying a "golang" function fails with the following error:

Error: function helloGo: InvalidParameterValueException: The runtime parameter of nodejs is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs4.3) while creating or updating functions.
	status code: 400, request id: 33f57c31-d3bb-11e6-8c58-f94bb7d2db37

