### PR TITLE
Add alias command

### DIFF
--- a/cmd/apex/alias/alias.go
+++ b/cmd/apex/alias/alias.go
@@ -1,0 +1,72 @@
+package alias
+
+import (
+	"errors"
+
+	"github.com/tj/cobra"
+
+	"github.com/apex/apex/cmd/apex/root"
+	"github.com/apex/apex/stats"
+)
+
+// alias name.
+var alias string
+
+// version name
+var version string
+
+// example output.
+const example = `
+    Alias prod as current version
+    $ apex alias prod
+
+    Alias prod as version
+    $ apex alias -v version prod
+
+    Alias prod as current version for specific function
+    $ apex alias prod function
+
+    Alias prod as version for specific function
+    $ apex alias -v version prod function
+`
+
+// Command config.
+var Command = &cobra.Command{
+	Use:     "alias [<name>...]",
+	Short:   "Create or update alias on functions",
+	Example: example,
+	PreRunE: preRun,
+	RunE:    run,
+}
+
+// Initialize.
+func init() {
+	root.Register(Command)
+
+	f := Command.Flags()
+	f.StringVarP(&version, "version", "v", "$LATEST", "Function version")
+}
+
+// PreRun errors if the alias argument is missing.
+func preRun(c *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return errors.New("Missing alias argument")
+	}
+
+	alias = args[0]
+	return nil
+}
+
+// Run command.
+func run(c *cobra.Command, args []string) error {
+	stats.Track("Alias", map[string]interface{}{
+		"has_version": version != "",
+		"args":        len(args),
+	})
+
+	if err := root.Project.LoadFunctions(args[1:]...); err != nil {
+		return err
+	}
+
+	return root.Project.CreateOrUpdateAlias(alias, version)
+}

--- a/cmd/apex/main.go
+++ b/cmd/apex/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/apex/apex/stats"
 
 	// commands
+	_ "github.com/apex/apex/cmd/apex/alias"
 	_ "github.com/apex/apex/cmd/apex/autocomplete"
 	_ "github.com/apex/apex/cmd/apex/build"
 	_ "github.com/apex/apex/cmd/apex/delete"


### PR DESCRIPTION
Add alias command base on this discussion #364 but I change from the last comment a bit by adding function name as the last argument instead of version name

- apex alias <alias name> for adding alias all functions with the name
- apex alias <alias name> <function name> for adding alias on specific function
- apex alias -v <version> <alias name> for adding alias on specific version
- apex alias -v <version> <alias name> <function name> for adding alias on specific version and specific function