### PR TITLE
Updated AWS NodeJS Runtime keyword.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -132,7 +132,7 @@ Each function uses a function.json configuration file to define function-specifi
 {
   "name": "bar",
   "description": "Node.js example function",
-  "runtime": "nodejs",
+  "runtime": "nodejs4.3",
   "memory": 128,
   "timeout": 5,
   "role": "arn:aws:iam::293503197324:role/lambda"


### PR DESCRIPTION
nodejs updated to nodejs4.3.

AWS Was returning the following error using the old "nodejs" runtime keyword: "Error: function [FUNCTION NAME]: InvalidParameterValueException: The runtime parameter of nodejs is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs4.3) while creating or updating functions."


Before sending a pull-request please open an issue to discuss new features or non-trivial changes.

Thanks for your contribution!
