### PR TITLE
Fix regex for older grep versions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ elif [ "$UNAME" = "OpenBSD" ] ; then
 
 fi
 
-LATEST=$(curl -s https://api.github.com/repos/apex/apex/tags | grep -Eo '"name":.*?[^\\]",'  | head -n 1 | sed 's/[," ]//g' | cut -d ':' -f 2)
+LATEST=$(curl -s https://api.github.com/repos/apex/apex/tags | grep -Eo '"name":.*[^\\]",'  | head -n 1 | sed 's/[," ]//g' | cut -d ':' -f 2)
 URL="https://github.com/apex/apex/releases/download/$LATEST/apex_$PLATFORM"
 DEST=${DEST:-/usr/local/bin/apex}
 


### PR DESCRIPTION
Fix the install script on OpenBSD which has an older version of grep.

See comment here https://github.com/apex/apex/issues/400#issuecomment-278069309