### PR TITLE
[#680] fix alias command example by removing v prefix: v5 should be just 5

### DIFF
--- a/docs/alias.md
+++ b/docs/alias.md
@@ -18,7 +18,7 @@ $ apex alias prod api_*
 Alias all functions of version 5 to "prod":
 
 ```
-$ apex alias -v v5 prod
+$ apex alias -v 5 prod
 ```
 
 Alias specific function to "stage":
@@ -30,5 +30,5 @@ $ apex alias stage myfunction
 Alias specific function's version 10 to "stage":
 
 ```
-$ apex alias -v v10 stage myfunction
+$ apex alias -v 10 stage myfunction
 ```


### PR DESCRIPTION
Closes #680:

The [documentation](https://github.com/apex/apex/blob/master/docs/alias.md) uses the `v` prefix (e.g. `v5`) when specifying versions with the `alias` command, but the command expects the bare numbers or `$LATEST` as specified in the error message. The fix is to simply remove the `v` prefix from the examples.

For example:

    > apex alias -v v3 prod my_function
       ⨯ Error: function my_function: ValidationException: 1 validation error detected: Value 'v3' at 'functionVersion' failed to satisfy constraint: Member must satisfy regular expression pattern: (\$LATEST|[0-9]+)
            status code: 400, request id: 10da2dba-f75a-11e6-acb8-21311b9e82b8
    > apex alias -v 3 prod my_function
       • updated alias prod        env= function=my_function version=3
