### PR TITLE
Minor change: Link to Documentation on website

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -180,7 +180,7 @@ $ echo '{ "name": "Tobi" }' | apex invoke bar
 { "hello": "Tobi" }
 ```
 
-See the [Documentation](docs) for more information.
+See the [Documentation](http://apex.run) for more information.
 
 ## Links
 


### PR DESCRIPTION
The link for more information in the readme points to the GitHub repo's docs folder, and it seems like it should point to http://apex.run instead. Especially since docs folder has no readme, so it's really just a list of Markdown files...
