### PR TITLE
add context to gh ListReleases call

### DIFF
--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+        "context"
 
 	"github.com/apex/log"
 	"github.com/google/go-github/github"
@@ -21,7 +22,7 @@ func Upgrade(version string) error {
 
 	// fetch releases
 	gh := github.NewClient(nil)
-	releases, _, err := gh.Repositories.ListReleases("apex", "apex", nil)
+	releases, _, err := gh.Repositories.ListReleases(context.Background(), "apex", "apex", nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
this patch is to fix #690

this patch adds the `context` import and uses `context.Background()` as per the instructions in this commit:

https://github.com/google/go-github/commit/23d6cb9cacb5aa314e93d600fe20a48496a718d4


