### PR TITLE
Fix formatting in docs

### DIFF
--- a/docs/aws-credentials.md
+++ b/docs/aws-credentials.md
@@ -50,7 +50,7 @@ You may store the profile name in the project.json file itself as shown in the f
 }
 ```
 
-## Via IAM Role
+## Via IAM Role
 
 Using an IAM role can be achieved in two ways, via the __AWS_ROLE__ environment variable or via a command line flag `--iamrole`. As with other Apex credential loading, the command line flag will supersede the environment variable.
 


### PR DESCRIPTION
Looks like some unusual whitespace was preventing the Markdown heading from rendering.

Apologies if there's anything amiss with this PR... I'm trying out GitHub's web interface for "editing" files.