### PR TITLE
fix webpack2 example for version 2.3.1 - fixes #708

### DIFF
--- a/_examples/babel-webpack2/package.json
+++ b/_examples/babel-webpack2/package.json
@@ -13,6 +13,6 @@
     "babel-plugin-transform-runtime": "^6.22.0",
     "babel-preset-latest": "^6.22.0",
     "babel-preset-stage-0": "^6.22.0",
-    "webpack": "2.2.1"
+    "webpack": "2.3.1"
   }
 }

--- a/_examples/babel-webpack2/webpack.config.babel.js
+++ b/_examples/babel-webpack2/webpack.config.babel.js
@@ -1,11 +1,12 @@
 // NOTE: paths are relative to each functions folder
+import path from 'path';
 import Webpack from 'webpack';
 
 export default {
   entry: './src/index.js',
   target: 'node',
   output: {
-    path: './lib',
+    path: path.join(process.cwd(), 'lib'),
     filename: 'index.js',
     libraryTarget: 'commonjs2',
   },


### PR DESCRIPTION
Webpack requires output paths to be absolute since version 2.3.0.
This PR upgrades webpack's version to 2.3.1 and sets the output path to be absolute.