### PR TITLE
Fixes empty DeadLetterARN config triggering deploy no matter what.

### DIFF
--- a/function/function.go
+++ b/function/function.go
@@ -779,9 +779,12 @@ func (f *Function) configChanged(config *lambda.GetFunctionOutput) bool {
 			Subnets:        f.VPC.Subnets,
 			SecurityGroups: f.VPC.SecurityGroups,
 		},
-		DeadLetterConfig: lambda.DeadLetterConfig{
+	}
+
+	if f.DeadLetterARN != "" {
+		localConfig.DeadLetterConfig = lambda.DeadLetterConfig{
 			TargetArn: &f.DeadLetterARN,
-		},
+		}
 	}
 
 	remoteConfig := &diffConfig{


### PR DESCRIPTION
Possibly Closes #701

I tested this by newly creating a project with `apex init` and checking that multiple `apex deploy` will not redeploy code.