### PR TITLE
refactor example to use nodejs version 6.10

### DIFF
--- a/_examples/babel-webpack2/project.json_stub
+++ b/_examples/babel-webpack2/project.json_stub
@@ -1,5 +1,5 @@
 {
-  "runtime": "nodejs4.3",
+  "runtime": "nodejs6.10",
   "handler": "lib.default",
   "hooks": {
     "build": "../../node_modules/.bin/webpack --config ../../webpack.config.babel.js --bail",


### PR DESCRIPTION
updates babel2 webpack example to use nodejs6.10