### PR TITLE
Add ListFunctions to min IAM policy for aliasing to another alias

### DIFF
--- a/docs/aws-credentials.md
+++ b/docs/aws-credentials.md
@@ -78,6 +78,7 @@ Below is a policy for AWS [Identity and Access Management](http://aws.amazon.com
         "iam:AttachRolePolicy",
         "iam:PassRole",
         "lambda:GetFunction",
+        "lambda:ListFunctions",
         "lambda:CreateFunction",
         "lambda:DeleteFunction",
         "lambda:InvokeFunction",


### PR DESCRIPTION
`ListFunctions` permission is required when trying to setting an alias to another one.

If the permission is missing, setting alias to another one fails with following validation error
```
⨯ Error: function executor: ValidationException: 1 validation error detected: Value 'dev' at 
'functionVersion' failed to satisfy constraint: Member must satisfy regular expression pattern: 
(\$LATEST|[0-9]+)
```