### PR TITLE
Ensure Function.GetVersionFromAlias error is shown. Fixes #734

### DIFF
--- a/project/project.go
+++ b/project/project.go
@@ -390,14 +390,14 @@ func (p *Project) CreateOrUpdateAlias(alias, version string) error {
 				version, err := fn.GetVersionFromAlias(version)
 				if err != nil {
 					err = fmt.Errorf("function %s: %s", fn.Name, err)
+					errs <- err
 				}
 
 				err = fn.CreateOrUpdateAlias(alias, version)
 				if err != nil {
 					err = fmt.Errorf("function %s: %s", fn.Name, err)
+					errs <- err
 				}
-
-				errs <- err
 			}()
 		}
 


### PR DESCRIPTION
If GetVersionFromAlias() returns an error which subsequently results in
an error in CreateOrUpdateAlias(), the local err variable will be
overwritten with the CreateOrUpdateAlias() error.

Instead, add both instances to the errs channel.
