### PR TITLE
Includes babel-runtime fix the following error message

### DIFF
--- a/_examples/babel-webpack2/package.json
+++ b/_examples/babel-webpack2/package.json
@@ -13,6 +13,7 @@
     "babel-plugin-transform-runtime": "^6.22.0",
     "babel-preset-latest": "^6.22.0",
     "babel-preset-stage-0": "^6.22.0",
+    "babel-runtime": "^6.23.0",
     "webpack": "2.3.1"
   }
 }


### PR DESCRIPTION
Fix this error:

```
module.js:327
    throw err;
    ^

Error: Cannot find module 'babel-runtime/core-js/json/stringify'
    at Function.Module._resolveFilename (module.js:325:15)
    at Function.Module._load (module.js:276:25)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/Users/everton/Projects/mailhooks-lambdas/webpack.config.babel.js:7:18)
    at Module._compile (module.js:409:26)
    at loader (/Users/everton/Projects/mailhooks-lambdas/node_modules/babel-core/node_modules/babel-register/lib/node.js:144:5)
    at Object.require.extensions.(anonymous function) [as .js] (/Users/everton/Projects/mailhooks-lambdas/node_modules/babel-core/node_modules/babel-register/lib/node.js:154:7)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
```