### PR TITLE
Remove uneeded grep parameters that are breaking BSD grep in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ elif [ "$UNAME" = "OpenBSD" ] ; then
 
 fi
 
-LATEST=$(curl -s https://api.github.com/repos/apex/apex/tags | grep -Eo '"name":.*[^\\]",'  | head -n 1 | sed 's/[," ]//g' | cut -d ':' -f 2)
+LATEST=$(curl -s https://api.github.com/repos/apex/apex/tags | grep name  | head -n 1 | sed 's/[," ]//g' | cut -d ':' -f 2)
 URL="https://github.com/apex/apex/releases/download/$LATEST/apex_$PLATFORM"
 DEST=${DEST:-/usr/local/bin/apex}
 


### PR DESCRIPTION
Per [issue/761](https://github.com/apex/apex/issues/761). Change the grep parameters in install.sh that were breaking on OSX (and presumably for anyone else who doesn't have the privilege of GNU grep)