### PR TITLE
change exact runtime matching to prefix matching

### DIFF
--- a/plugins/clojure/clojure.go
+++ b/plugins/clojure/clojure.go
@@ -32,7 +32,7 @@ type Plugin struct{}
 
 // Open adds the shim and golang defaults.
 func (p *Plugin) Open(fn *function.Function) error {
-	if fn.Runtime != Runtime {
+	if !strings.HasPrefix(fn.Runtime, "clojure") {
 		return nil
 	}
 
@@ -57,7 +57,7 @@ func (p *Plugin) Open(fn *function.Function) error {
 
 // Build adds the jar contents to zipfile.
 func (p *Plugin) Build(fn *function.Function, zip *archive.Zip) error {
-	if fn.Runtime != Runtime {
+	if !strings.HasPrefix(fn.Runtime, "clojure") {
 		return nil
 	}
 

--- a/plugins/golang/golang.go
+++ b/plugins/golang/golang.go
@@ -2,6 +2,8 @@
 package golang
 
 import (
+	"strings"
+
 	"github.com/apex/apex/function"
 	"github.com/apex/apex/plugins/nodejs"
 )
@@ -20,7 +22,7 @@ type Plugin struct{}
 
 // Open adds the shim and golang defaults.
 func (p *Plugin) Open(fn *function.Function) error {
-	if fn.Runtime != Runtime {
+	if !strings.HasPrefix(fn.Runtime, "golang") {
 		return nil
 	}
 
@@ -29,7 +31,7 @@ func (p *Plugin) Open(fn *function.Function) error {
 	}
 
 	fn.Shim = true
-	fn.Runtime = nodejs.Runtime43
+	fn.Runtime = nodejs.Runtime
 
 	if fn.Hooks.Clean == "" {
 		fn.Hooks.Clean = "rm -f main"

--- a/plugins/inference/inference.go
+++ b/plugins/inference/inference.go
@@ -16,7 +16,7 @@ func init() {
 	function.RegisterPlugin("inference", &Plugin{
 		Files: map[string]string{
 			"main.py":             python.Runtime,
-			"index.js":            nodejs.Runtime6_10,
+			"index.js":            nodejs.Runtime,
 			"main.go":             golang.Runtime,
 			"target/apex.jar":     java.Runtime,
 			"build/libs/apex.jar": java.Runtime,

--- a/plugins/java/java.go
+++ b/plugins/java/java.go
@@ -40,7 +40,7 @@ type Plugin struct{}
 // assumed that the build tool generating the fat JAR will handle that workflow
 // on its own.
 func (p *Plugin) Open(fn *function.Function) error {
-	if fn.Runtime != Runtime {
+	if !strings.HasPrefix(fn.Runtime, "java") {
 		return nil
 	}
 
@@ -61,7 +61,7 @@ func (p *Plugin) Open(fn *function.Function) error {
 
 // Build adds the jar contents to zipfile.
 func (p *Plugin) Build(fn *function.Function, zip *archive.Zip) error {
-	if fn.Runtime != Runtime {
+	if !strings.HasPrefix(fn.Runtime, "java") {
 		return nil
 	}
 	fn.Runtime = RuntimeCanonical

--- a/plugins/nodejs/nodejs.go
+++ b/plugins/nodejs/nodejs.go
@@ -1,27 +1,18 @@
 // Package nodejs implements the "nodejs" runtime.
 package nodejs
 
-import "github.com/apex/apex/function"
+import (
+	"github.com/apex/apex/function"
+	"strings"
+)
 
 const (
 	// Runtime name used by Apex and by AWS Lambda for Node.js 0.10
 	Runtime = "nodejs"
-
-	// Runtime43 name used by Apex and by AWS Lambda for Node.js 4.3.2
-	Runtime43 = "nodejs4.3"
-
-	// Runtime43Edge name used by Apex and by AWS Lambda for Node.js 4.3.2 Edge
-	Runtime43Edge = "nodejs4.3-edge"
-
-	// Runtime6_10 name used by Apex and by AWS Lambda for Node.js 6.10
-	Runtime6_10 = "nodejs6.10"
 )
 
 func init() {
 	function.RegisterPlugin(Runtime, &Plugin{})
-	function.RegisterPlugin(Runtime43, &Plugin{})
-	function.RegisterPlugin(Runtime43Edge, &Plugin{})
-	function.RegisterPlugin(Runtime6_10, &Plugin{})
 }
 
 // Plugin implementation.
@@ -29,8 +20,12 @@ type Plugin struct{}
 
 // Open adds nodejs defaults.
 func (p *Plugin) Open(fn *function.Function) error {
-	if !runtimeSupported(fn) {
+	if !strings.HasPrefix(fn.Runtime, "nodejs") {
 		return nil
+	}
+
+	if fn.Runtime == "nodejs" {
+		fn.Runtime = Runtime
 	}
 
 	if fn.Handler == "" {
@@ -38,8 +33,4 @@ func (p *Plugin) Open(fn *function.Function) error {
 	}
 
 	return nil
-}
-
-func runtimeSupported(fn *function.Function) bool {
-	return fn.Runtime == Runtime || fn.Runtime == Runtime43 || fn.Runtime == Runtime43Edge || fn.Runtime == Runtime6_10
 }

--- a/plugins/rust_gnu/rust_gnu.go
+++ b/plugins/rust_gnu/rust_gnu.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/apex/apex/function"
 	"github.com/apex/apex/plugins/nodejs"
+	"strings"
 )
 
 func init() {
@@ -21,7 +22,7 @@ type Plugin struct{}
 
 // Open adds the shim and golang defaults.
 func (p *Plugin) Open(fn *function.Function) error {
-	if fn.Runtime != Runtime {
+	if !strings.HasPrefix(fn.Runtime, "rust-gnu") {
 		return nil
 	}
 
@@ -30,7 +31,7 @@ func (p *Plugin) Open(fn *function.Function) error {
 	}
 
 	fn.Shim = true
-	fn.Runtime = nodejs.Runtime43
+	fn.Runtime = nodejs.Runtime
 
 	if fn.Hooks.Clean == "" {
 		fn.Hooks.Clean = "rm -f main"

--- a/plugins/rust_musl/rust_musl.go
+++ b/plugins/rust_musl/rust_musl.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/apex/apex/function"
 	"github.com/apex/apex/plugins/nodejs"
+	"strings"
 )
 
 func init() {
@@ -21,7 +22,7 @@ type Plugin struct{}
 
 // Open adds the shim and golang defaults.
 func (p *Plugin) Open(fn *function.Function) error {
-	if fn.Runtime != Runtime {
+	if !strings.HasPrefix(fn.Runtime, "rust-musl") {
 		return nil
 	}
 
@@ -30,7 +31,7 @@ func (p *Plugin) Open(fn *function.Function) error {
 	}
 
 	fn.Shim = true
-	fn.Runtime = nodejs.Runtime43
+	fn.Runtime = nodejs.Runtime
 
 	if fn.Hooks.Clean == "" {
 		fn.Hooks.Clean = "rm -f main"


### PR DESCRIPTION
- add prefix runtime checks for node & rust
- add default node version for inferencing on plugin init

Closes #731.
