### PR TITLE
shim: added support for non structural logging

### DIFF
--- a/shim/index.js
+++ b/shim/index.js
@@ -32,8 +32,13 @@ var out = byline(proc.stdout)
 
 out.on('data', function(line){
   if (process.env.DEBUG_SHIM) console.log('[shim] parsing: `%s`', line)
-  var msg = JSON.parse(line)
-  callback(msg.error, msg.value)
+  try {
+    var msg = JSON.parse(line)
+    callback(msg.error, msg.value)
+  } catch (err) {
+    if (process.env.DEBUG_SHIM) console.error('[shim] parsing error: `%s`', err)
+    callback(null, line)
+  }
 })
 
 /**


### PR DESCRIPTION
Currently when using just fmt.Println the shim will break in a bad way. This fixes this behaviour allowing us to use non structural logging.