### PR TITLE
Fix installer for users with a .curlrc

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ elif [ "$UNAME" = "OpenBSD" ] ; then
 
 fi
 
-LATEST=$(curl -s https://api.github.com/repos/apex/apex/tags | grep name  | head -n 1 | sed 's/[," ]//g' | cut -d ':' -f 2)
+LATEST=$(curl -s -A 'curl' https://api.github.com/repos/apex/apex/tags | grep name  | head -n 1 | sed 's/[," ]//g' | cut -d ':' -f 2)
 URL="https://github.com/apex/apex/releases/download/$LATEST/apex_$PLATFORM"
 DEST=${DEST:-/usr/local/bin/apex}
 


### PR DESCRIPTION
The github API strips carriage returns for some user agents.
This fixes installation for users with a `.curlrc` containing something like
`user-agent = "Mozilla/5.0"`.