### PR TITLE
Update the handler

### DIFF
--- a/_examples/babel-webpack2/project.json_stub
+++ b/_examples/babel-webpack2/project.json_stub
@@ -1,6 +1,6 @@
 {
   "runtime": "nodejs6.10",
-  "handler": "lib.default",
+  "handler": "lib/index.handle",
   "hooks": {
     "build": "../../node_modules/.bin/webpack --config ../../webpack.config.babel.js --bail",
     "clean": "rm -fr lib"


### PR DESCRIPTION
Updated the `handler` value. Previous value was returning this when invoking the functions:

` ⨯ Error: function response: Handler 'default' missing on module 'lib'`