### PR TITLE
fixes #815 - clojure deployments being doubled by java plugin

### DIFF
--- a/function/function.go
+++ b/function/function.go
@@ -51,8 +51,8 @@ var defaultPlugins = []string{
 	"golang",
 	"python",
 	"nodejs",
-	"clojure",
 	"java",
+	"clojure",
 	"env",
 	"shim",
 }


### PR DESCRIPTION
The easiest answer I could think of to java plugin adding doubles of most files.
Here's a link to my ramblings on this in Slack: https://apex-dev.slack.com/archives/C65RYLQ5B/p1506550906000412