### PR TITLE
Add dependency for go example

### DIFF
--- a/_examples/go/functions/simple/function.json
+++ b/_examples/go/functions/simple/function.json
@@ -1,0 +1,6 @@
+{
+  "description": "Example with go dependency on an external package",
+  "hooks":{
+    "build": "go get -v -t -d ./..."
+  }
+}


### PR DESCRIPTION
I don't think the example should assume dependencies are installed. This step explicitly adds this in the example. 

The python example is very similar and installs dependencies too.