### PR TITLE
Allow for Plugins to specify a build artifact (fixes issue #887)

### DIFF
--- a/function/function_test.go
+++ b/function/function_test.go
@@ -284,7 +284,7 @@ func TestFunction_Rollback_fewVersions(t *testing.T) {
 	}
 	err := fn.Rollback()
 
-	assert.EqualError(t, err, "Can't rollback. Only one version deployed.")
+	assert.EqualError(t, err, "can't rollback. Only one version deployed")
 }
 
 func TestFunction_Rollback_previousVersion(t *testing.T) {
@@ -410,7 +410,7 @@ func TestFunction_RollbackVersion_sameVersion(t *testing.T) {
 	}
 	err := fn.RollbackVersion("2")
 
-	assert.EqualError(t, err, "Specified version currently deployed.")
+	assert.EqualError(t, err, "specified version currently deployed")
 }
 
 func TestFunction_RollbackVersion_success(t *testing.T) {

--- a/plugins/clojure/clojure.go
+++ b/plugins/clojure/clojure.go
@@ -1,16 +1,10 @@
 package clojure
 
 import (
-	azip "archive/zip"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
-
-	"github.com/apex/apex/archive"
 	"github.com/apex/apex/function"
+	"path/filepath"
 )
 
 func init() {
@@ -23,11 +17,9 @@ const (
 
 	// RuntimeCanonical represents names used by AWS Lambda
 	RuntimeCanonical = "java8"
-
-	jarFile = "apex.jar"
 )
 
-// Plugin Does plugin things
+// Plugin Does plugin things.
 type Plugin struct{}
 
 // Open adds the shim and golang defaults.
@@ -44,60 +36,15 @@ func (p *Plugin) Open(fn *function.Function) error {
 		fn.Hooks.Clean = "rm -fr target"
 	}
 
-	if _, err := os.Stat(".apexignore"); err != nil {
-		// Since we're deploying a fat jar, we don't need anything else.
-		fn.IgnoreFile = []byte(`
-*
-!**/apex.jar
-`)
+	if fn.Config.BuildArtifact == "" {
+		fn.Config.BuildArtifact = "target/apex.jar"
 	}
+	fn.Config.BuildArtifact = filepath.Join(fn.Path, fn.Config.BuildArtifact)
 
 	return nil
 }
 
-// Build adds the jar contents to zipfile.
-func (p *Plugin) Build(fn *function.Function, zip *archive.Zip) error {
-	if !strings.HasPrefix(fn.Runtime, "clojure") {
-		return nil
-	}
-
-	jar := filepath.Join(fn.Path, "target", jarFile)
-	if _, err := os.Stat(jar); err != nil {
-		return errors.Errorf("missing jar file %q", jar)
-	}
-
-	fn.Log.Debug("appending compiled files")
-	reader, err := azip.OpenReader(jar)
-	if err != nil {
-		return errors.Wrap(err, "opening zip")
-	}
-	defer reader.Close()
-
-	for _, file := range reader.File {
-		parts := strings.Split(file.Name, ".")
-		ext := parts[len(parts)-1]
-
-		if ext == "clj" || ext == "cljx" || ext == "cljc" {
-			continue
-		}
-
-		r, err := file.Open()
-		if err != nil {
-			return errors.Wrap(err, "opening file")
-		}
-
-		b, err := ioutil.ReadAll(r)
-		if err != nil {
-			return errors.Wrap(err, "reading file")
-		}
-		r.Close()
-
-		zip.AddBytes(file.Name, b)
-	}
-
-	return nil
-}
-
+// Deploy sets actual runtime to java.
 func (p *Plugin) Deploy(fn *function.Function) error {
 	if !strings.HasPrefix(fn.Runtime, "clojure") {
 		return nil


### PR DESCRIPTION
We'd talked about doing this in the past (https://github.com/apex/apex/issues/673) and I was against this method then because it:
- bypasses `.apexignore` which could be confusing.
- bypasses the normal zip generation pipeline which makes interactions with other plugins more complicated if not impossible.
- breaks the hash check on deploy for clojure projects.

Unfortunately though, this is only method that will guarantee what get's deployed is what clojure users expect and I think that's more important.

Thoughts?