### PR TITLE
add `region` field to project configuration

### DIFF
--- a/cmd/apex/root/root.go
+++ b/cmd/apex/root/root.go
@@ -114,9 +114,11 @@ func Prepare(c *cobra.Command, args []string) error {
 		}
 	}
 
+	configProfile, configRegion, _ := utils.ProfileAndRegionFromConfig(environment)
+
 	// profile from flag, config, env, "default"
 	if profile == "" {
-		profile, _ = utils.ProfileFromConfig(environment)
+		profile = configProfile
 		if profile == "" {
 			profile = os.Getenv("AWS_PROFILE")
 			if profile == "" {
@@ -128,11 +130,14 @@ func Prepare(c *cobra.Command, args []string) error {
 	// the default SharedCredentialsProvider checks the env
 	os.Setenv("AWS_PROFILE", profile)
 
-	// region from flag, env, file
+	// region from flag, config, env, file
 	if region == "" {
-		region = os.Getenv("AWS_REGION")
+		region = configRegion
 		if region == "" {
-			region, _ = utils.GetRegion(profile)
+			region = os.Getenv("AWS_REGION")
+			if region == "" {
+				region, _ = utils.GetRegion(profile)
+			}
 		}
 	}
 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -116,6 +116,12 @@ Name of the AWS profile to use, this is the name used to locate AWS credentials 
 
 - type: `string`
 
+### region
+
+Name of the AWS region to use. Use this if you'd prefer not to specify `AWS_REGION` or `--region`.
+
+- type: `string`
+
 ### defaultEnvironment
 
 Default infrastructure environment.

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -133,8 +133,8 @@ func ParseEnv(env []string) (map[string]string, error) {
 	return m, nil
 }
 
-// ProfileFromConfig attempts to load the .profile setting from `environment`'s config.
-func ProfileFromConfig(environment string) (string, error) {
+// ProfileAndRegionFromConfig attempts to load the .profile setting from `environment`'s config.
+func ProfileAndRegionFromConfig(environment string) (string, string, error) {
 	configFile := "project.json"
 
 	if environment != "" {
@@ -143,19 +143,20 @@ func ProfileFromConfig(environment string) (string, error) {
 
 	f, err := os.Open(configFile)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	defer f.Close()
 
 	var v struct {
 		Profile string `json:"profile"`
+		Region  string `json:"region"`
 	}
 
 	if err := json.NewDecoder(f).Decode(&v); err != nil {
-		return "", err
+		return "", "", err
 	}
 
-	return v.Profile, nil
+	return v.Profile, v.Region, nil
 }
 
 // AssumeRole uses STS to assume the given `role`.


### PR DESCRIPTION
From #883 

Add `region` field to project.json.

The priority of region specification will be following:
(Most Prior) `--region` > project.json 🆕 > `AWS_REGION` env > `~/.aws/config` (Least prior)