### PR TITLE
fix Windows golang function builds. Closes #832

### DIFF
--- a/archive/zip.go
+++ b/archive/zip.go
@@ -73,6 +73,7 @@ func (z *Zip) AddFile(path string, file *os.File) error {
 	}
 	header.Name = path
 	header.Method = zip.Deflate
+	header.SetMode(os.ModePerm)
 	header.SetModTime(time.Unix(0, 0))
 
 	zippedFile, err := z.writer.CreateHeader(header)

--- a/plugins/golang/golang.go
+++ b/plugins/golang/golang.go
@@ -3,6 +3,7 @@ package golang
 
 import (
 	"strings"
+	"runtime"
 
 	"github.com/apex/apex/function"
 )
@@ -30,7 +31,11 @@ func (p *Plugin) Open(fn *function.Function) error {
 	}
 
 	if fn.Hooks.Build == "" {
-		fn.Hooks.Build = "GOOS=linux GOARCH=amd64 go build -o main *.go"
+		if runtime.GOOS == "windows" {
+			fn.Hooks.Build = "SET GOOS=linux&&SET GOARCH=amd64&&go build -o main"
+		} else {
+			fn.Hooks.Build = "GOOS=linux GOARCH=amd64 go build -o main *.go"
+		}
 	}
 
 	if fn.Handler == "" {
@@ -38,7 +43,11 @@ func (p *Plugin) Open(fn *function.Function) error {
 	}
 
 	if fn.Hooks.Clean == "" {
-		fn.Hooks.Clean = "rm -f main"
+		if runtime.GOOS == "windows" {
+			fn.Hooks.Clean = "del /F /Q main"
+		} else {
+			fn.Hooks.Clean = "rm -f main"
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This does two things to fix Windows golang

Use `runtime.GOOS` in `plugins/golang` to determine the appropriate commands to run to compile the Golang functions. This fixes the problem with `apex build` for golang on Windows.

Sets the Mode on files zipped up to be executable. This is based on the explanation of zip archive requirements from `github.com/aws/aws-go-lambda/cmd/build-lambda-zip` this allows the lambda to run.

The function in the screen capture is a copy of the example golang function.

![iss832](https://user-images.githubusercontent.com/3035691/49170009-02ed9e80-f2f0-11e8-966d-bc237d3fb338.gif)

