### PR TITLE
install.sh: retry failed downloads

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -194,7 +194,7 @@ http_download() {
   headerflag=''
   destflag=''
   if is_command curl; then
-    cmd='curl --fail -sSL'
+    cmd='curl --retry 3 --fail -sSL'
     destflag='-o'
     headerflag='-H'
   elif is_command wget; then


### PR DESCRIPTION
Occasionally, downloading the Apex binary fails with a "Empty reply"
error from Github. Since the install script is only issuing GET
requests these should be safe to retry, and we can increase download
reliability by doing so.

The `--retry` flag was added in version 7.12.3, released in December
2004, so it should be available on most systems that are downloading
Apex.

Fixes #924.



Before sending a pull-request please open an issue to discuss new features or non-trivial changes.

Thanks for your contribution!