### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+*.zip
+.DS_Store
+examples/go/main
+_examples/ruby/functions/dependency/.bundle/
+_examples/ruby/functions/dependency/Gemfile.lock
+cov.out
+node_modules
+vendor/
+.envrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.11.4-alpine AS builder
+
+RUN apk add --no-cache ca-certificates git make gcc libc-dev
+WORKDIR /go/src/github.com/apex/apex
+
+ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on
+
+COPY ./go.mod ./go.sum ./
+RUN go mod download
+
+COPY ./ ./
+
+RUN make local
+
+FROM alpine AS runtime
+
+RUN apk add --no-cache ca-certificates
+COPY --from=builder /go/bin/apex /bin/apex
+
+ENTRYPOINT ["/bin/apex"]


### PR DESCRIPTION
I would like to use an `apex` binary built on the latest master branch which supports ruby runtime.
But for now, the official binaries have not been released yet, so I'm building the master branch by myself and `apex deploy` from my local PC. This is obviously not desirable for team development.

I wrote a Dockerfile to eliminate dependencies on build environment. This implementation simply copies files current branch, so this can also build a forked feature branch by ourselves.

I think it might be useful to other people such as me 😄 

Note: 
To actually deploy a ruby runtime, ruby related dependencies such as  `bundle` are additionally required.  So we need to inherit this Dockerfile and add a ruby-related dependency.
However, since the apex supports multiple runtimes, I did not intentionally add them here.
