### PR TITLE
Remove reference to Golang using the shim function

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -28,7 +28,7 @@ Description of the function. This is used as the description in AWS Lambda.
 
 ### runtime
 
-Runtime of the function. This is used as the runtime in AWS Lambda, or when required, is used to determine that the Node.js shim should be used. For example when this field is "golang", the canonical runtime used is "nodejs" and a shim is injected into the zip file.
+Runtime of the function. This is used as the runtime in AWS Lambda, or when required, is used to determine that the Node.js shim should be used. For example when this field is "perl", the canonical runtime used is "nodejs" and a shim is injected into the zip file.
 
 - type: `string`
 - required


### PR DESCRIPTION
AWS Lambda officialy supports Golang and this change is already reflected on the codebase https://github.com/apex/apex/pull/864, therefore this reference is outdated.

I put Perl in there as a new example, but any language can fit the bill.